### PR TITLE
Twitter stream compression

### DIFF
--- a/Twitterizer2.Streaming/StreamOptions.cs
+++ b/Twitterizer2.Streaming/StreamOptions.cs
@@ -68,5 +68,12 @@ namespace Twitterizer.Streaming
         /// </summary>
         /// <value>The locations.</value>
         public List<Location> Locations { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to request the use of GZip compression on the stream.
+        /// </summary>
+        /// <value>Boolean.</value>
+        /// <remarks>Will use the recently introduced GZip compression to decrease bandwitdth.</remarks>
+        public bool UseCompression { get; set; }
     }
 }

--- a/Twitterizer2.Streaming/TwitterStream.cs
+++ b/Twitterizer2.Streaming/TwitterStream.cs
@@ -286,7 +286,10 @@ namespace Twitterizer.Streaming
 
                 if (StreamOptions.Track != null && StreamOptions.Track.Count > 0)
                     builder.Parameters.Add("track", string.Join(",", StreamOptions.Track.ToArray()));
-            }
+
+                if (StreamOptions.UseCompression != null)
+                    builder.Parameters.Add("UseCompression", StreamOptions.UseCompression);
+                    }
         }
 
         /// <summary>

--- a/Twitterizer2/OAuth/WebRequestBuilder.cs
+++ b/Twitterizer2/OAuth/WebRequestBuilder.cs
@@ -285,11 +285,31 @@ namespace Twitterizer
 
 				this.Verb = HTTPVerb.POST;
 			}
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.RequestUri);
+            //Deal with the special case where we need to add the compression header if the UseCompression key is in the parameters dictionary.
+            object UseCompressionObj;
+            if (Parameters.TryGetValue("UseCompression", out UseCompressionObj)) 
+            {
+                //now try and convert to a boolean.
+                bool UseCompression = false;
+                try
+                {
+                    UseCompression = Convert.ToBoolean(UseCompressionObj);
+                }
+                catch (Exception e)
+                {
+                    throw; //properly rethrow the exception preserving stack trace.
+                }
+                if (UseCompression ==true)
+                    request.AutomaticDecompression =DecompressionMethods.GZip | DecompressionMethods.Deflate;
+                else
+                    request.AutomaticDecompression =DecompressionMethods.None;
+            }
 #if SILVERLIGHT
             WebRequest.RegisterPrefix("http://", WebRequestCreator.ClientHttp);
             WebRequest.RegisterPrefix("https://", WebRequestCreator.ClientHttp);
+
 #endif
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.RequestUri);
 
 #if !SILVERLIGHT
             if (this.Proxy != null)
@@ -363,11 +383,11 @@ namespace Twitterizer
 			Dictionary<string, object> fieldsToInclude = new Dictionary<string, object>(this.Parameters.Where(p => !OAuthParametersToIncludeInHeader.Contains(p.Key) &&
                                          !SecretParameters.Contains(p.Key)).ToDictionary(p => p.Key, p => p.Value));
 
-			foreach (KeyValuePair<string, object> item in fieldsToInclude)
+            foreach (KeyValuePair<string, object> item in fieldsToInclude)
             {
                 if (item.Value is string)
-					requestParametersBuilder.AppendFormat("{0}={1}&", item.Key, UrlEncode((string)item.Value));
-            }
+                    requestParametersBuilder.AppendFormat("{0}={1}&", item.Key, UrlEncode((string)item.Value));
+            }        
 
             if (requestParametersBuilder.Length == 0)
                 return;


### PR DESCRIPTION
This patch adds a UseCompression variable to the StreamOptions class. This in turn
changes whether the request response stream is compressed using the
GZip/Deflate compression methods.
