### PR TITLE
Fix bug in CoordinateConverter and in SearchCommand

### DIFF
--- a/Twitterizer2/Methods/Geo/Coordinate.cs
+++ b/Twitterizer2/Methods/Geo/Coordinate.cs
@@ -108,8 +108,10 @@ namespace Twitterizer
                     //int depth = reader.Depth + 1;
                     double count = 1;
 
-                    while (reader.Read() && reader.Depth >= startDepth)
+                    while( reader.Read() )
                     {
+                        if( reader.Depth == startDepth && reader.TokenType == JsonToken.EndArray ) break;
+
                         if (new[] { JsonToken.StartArray, JsonToken.EndArray }.Contains(reader.TokenType))
                             continue;
 

--- a/Twitterizer2/Methods/Search/SearchCommand.cs
+++ b/Twitterizer2/Methods/Search/SearchCommand.cs
@@ -138,7 +138,7 @@ namespace Twitterizer.Commands
 
             if (options.UntilDate > new DateTime())
             {
-                this.RequestParameters.Add("until", options.UntilDate.ToString("{0:yyyy-MM-dd}", unitedStatesEnglishCulture));
+                this.RequestParameters.Add("until", options.UntilDate.ToString("yyyy-MM-dd", unitedStatesEnglishCulture));
             }
 
             switch (options.ResultType)


### PR DESCRIPTION
Fix bug in CoordinateConverter ReadJson
Bug found when reading user's status that contains coord, the converter 
read the EndObject of the parent object. Next Object can't be read in 
this case.
Escape case must be the EndArray while in the startDepth.

Fix bug in SearchCommend UntilDate ToString format.
Bug found when performing a search with UntilDate option. RequestParameters 
is invalid in this case.
