### PR TITLE
Fixed parse error bug with UserTimeline

### DIFF
--- a/Twitterizer2/Methods/Geo/Coordinate.cs
+++ b/Twitterizer2/Methods/Geo/Coordinate.cs
@@ -108,7 +108,7 @@ namespace Twitterizer
                     //int depth = reader.Depth + 1;
                     double count = 1;
 
-                    while (reader.Read() && reader.Depth >= startDepth)
+                    while (reader.Read() && reader.Depth > startDepth)
                     {
                         if (new[] { JsonToken.StartArray, JsonToken.EndArray }.Contains(reader.TokenType))
                             continue;

--- a/Twitterizer2/Methods/Tweets/Entities/TwitterEntityCollection.cs
+++ b/Twitterizer2/Methods/Tweets/Entities/TwitterEntityCollection.cs
@@ -92,7 +92,7 @@ using System.Linq.Expressions;
                 TwitterEntity entity = null;
                 try
                 {
-                    while (reader.Read() && reader.Depth >= startDepth)
+                    while (reader.Read() && reader.Depth > startDepth)
                     {
                         if (reader.TokenType == JsonToken.PropertyName && reader.Depth == startDepth + 1)
                         {
@@ -337,7 +337,7 @@ using System.Linq.Expressions;
                     int startDepth = reader.Depth;
 
                     // Start looping through all of the child nodes
-                    while (reader.Read() && reader.Depth >= startDepth)
+                    while (reader.Read() && reader.Depth > startDepth)
                     {
                         // If the current node isn't a property, skip it
                         if (reader.TokenType != JsonToken.PropertyName)


### PR DESCRIPTION
TwitterTimeline.UserTimeline generated a parse error. Checking a nest
depth was wrong and the loop never went out. I removed an equal from the
condition.
