### PR TITLE
Core(TwitterCommand): avoid calling Encoding.UTF8.GetString() twice

### DIFF
--- a/Twitterizer2/Core/TwitterCommand.cs
+++ b/Twitterizer2/Core/TwitterCommand.cs
@@ -274,7 +274,7 @@ namespace Twitterizer.Core
                 // Try to read the error message, if there is one.
                 try
                 {
-                    TwitterErrorDetails errorDetails = SerializationHelper<TwitterErrorDetails>.Deserialize(responseData);
+                    var errorDetails = SerializationHelper<TwitterErrorDetails>.Deserialize(twitterResponse.Content);
                     twitterResponse.ErrorMessage = errorDetails.ErrorMessage;
                 }
                 catch (Exception)


### PR DESCRIPTION
If the response was an error, the overload for Deserialize() that was
being used was the one that receives byte[], which in turn would call
Encoding.UTF8.GetString(), however that conversion had already been
done for extracting the twitterResponse.Content property.
